### PR TITLE
Fix typo 'briliant'

### DIFF
--- a/tree.hpp
+++ b/tree.hpp
@@ -144,7 +144,7 @@ namespace _tree_private {
 /////////
 // node classes
 
-//briliant evil-genius technique adapted from the gnu stl list
+//brilliant evil-genius technique adapted from the gnu stl list
 //implementation - node_base is used for sentinel nodes, and static_cast to
 //node is used for when we want to access the data - this avoids the overhead
 //of polymorphism and the wasted sizeof(T) space of using node for sentinels


### PR DESCRIPTION

    Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
    should be 'brilliant', you typed 'briliant'. I created this pull request to fix it!

    If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
    at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
    I’m aware of it.

    Looking for the source code of this bot? Well, you have to be patient! The bot is under development
    and I will publish the source code as soon as I’m finished with it.

    With kind regards,
    TheTypoMaster
                